### PR TITLE
outputs support

### DIFF
--- a/tfstate/lookup_test.go
+++ b/tfstate/lookup_test.go
@@ -18,6 +18,8 @@ func init() {
 }
 
 var TestNames = []string{
+	`output.foo`,
+	`output.bar`,
 	`data.aws_caller_identity.current`,
 	`aws_acm_certificate.main`,
 	`module.logs.aws_cloudwatch_log_group.main["app"]`,
@@ -81,6 +83,18 @@ var TestSuitesOK = []TestSuite{
 	},
 	TestSuite{
 		Key:    `aws_iam_role_policy_attachment.ec2[2].id`,
+		Result: nil,
+	},
+	TestSuite{
+		Key:    `output.foo.value`,
+		Result: "FOO",
+	},
+	TestSuite{
+		Key:    `output.bar.value[0]`,
+		Result: "A",
+	},
+	TestSuite{
+		Key:    `output.baz.value`,
 		Result: nil,
 	},
 }

--- a/tfstate/test/terraform.tfstate
+++ b/tfstate/test/terraform.tfstate
@@ -3,7 +3,27 @@
   "terraform_version": "0.12.16",
   "serial": 173,
   "lineage": "054d7292-3d84-0584-4590-24d6f3b17399",
-  "outputs": {},
+  "outputs": {
+    "foo": {
+      "value": "FOO",
+      "type": "string"
+    },
+    "bar": {
+      "value": [
+        "A",
+        "B",
+        "C"
+      ],
+      "type": [
+        "tuple",
+        [
+          "string",
+          "string",
+          "string"
+        ]
+      ]
+    }
+  },
   "resources": [
     {
       "mode": "data",


### PR DESCRIPTION
Supports [terraform output](https://www.terraform.io/docs/configuration/outputs.html) in tfstate.

```json
{
  "outputs": {
    "foo": {
      "value": "FOO",
      "type": "string"
    },
```

```console
$ tfstate-lookup output.foo.value
FOO

$ tfstate-lookup output.foo
{"type":"string","value":"FOO"}
```