### PR TITLE
Take care of recursive module

### DIFF
--- a/tfstate/lookup.go
+++ b/tfstate/lookup.go
@@ -217,8 +217,13 @@ func parseAddress(key string) (selectorFunc, string, error) {
 
 	var module string
 	if parts[0] == "module" {
-		module = "module." + parts[1]
-		parts = parts[2:] // remove module prefix
+		for i := len(parts) - 1; i >= 0; i-- {
+			if parts[i] == "module" {
+				module = strings.Join(parts[0:i+2], ".")
+				parts = parts[i+2:] // remove module prefix
+				break
+			}
+		}
 	}
 	if parts[0] == "data" {
 		selector = func(r resource) *instance {

--- a/tfstate/lookup_test.go
+++ b/tfstate/lookup_test.go
@@ -26,6 +26,7 @@ var TestNames = []string{
 	`module.logs.aws_cloudwatch_log_group.main["web"]`,
 	`aws_iam_role_policy_attachment.ec2[0]`,
 	`aws_iam_role_policy_attachment.ec2[1]`,
+	`module.webapp.module.ecs_task_roles.aws_iam_role.task_execution_role`,
 }
 
 var TestSuitesOK = []TestSuite{
@@ -95,6 +96,18 @@ var TestSuitesOK = []TestSuite{
 	},
 	TestSuite{
 		Key:    `output.baz.value`,
+		Result: nil,
+	},
+	TestSuite{
+		Key:    "module.webapp.module.ecs_task_roles.aws_iam_role.task_execution_role.name",
+		Result: "task-execution-role",
+	},
+	TestSuite{
+		Key:    "module.webapp.xxxx.ecs_task_roles.aws_iam_role.task_execution_role",
+		Result: nil,
+	},
+	TestSuite{
+		Key:    "xxxx.webapp.module.ecs_task_roles.aws_iam_role.task_execution_role",
 		Result: nil,
 	},
 }

--- a/tfstate/test/terraform.tfstate
+++ b/tfstate/test/terraform.tfstate
@@ -159,6 +159,34 @@
           "private": "bnVsbA=="
         }
       ]
+    },
+    {
+      "module": "module.webapp.module.ecs_task_roles",
+      "mode": "managed",
+      "type": "aws_iam_role",
+      "name": "task_execution_role",
+      "provider": "provider.aws",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "arn": "arn:aws:iam::123456789012:role/task-execution-role",
+            "assume_role_policy": "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Sid\":\"\",\"Effect\":\"Allow\",\"Principal\":{\"Service\":\"ecs-tasks.amazonaws.com\"},\"Action\":\"sts:AssumeRole\"}]}",
+            "create_date": "2019-11-18T07:57:06Z",
+            "description": "",
+            "force_detach_policies": false,
+            "id": "task-execution-role",
+            "max_session_duration": 3600,
+            "name": "task-execution-role",
+            "name_prefix": null,
+            "path": "/",
+            "permissions_boundary": null,
+            "tags": {},
+            "unique_id": "AAAAAAAAAAAA"
+          },
+          "private": "bnVsbA=="
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
My tfstate file has the following resources:
```
module.webapp.module.ecs_task_roles
```

This is the case of using the module within the module.
In this case, the query will not work.
```
$ tfstate-lookup module.webapp.module.ecs_task_roles.aws_iam_role.task_execution_role.name
null
```

I fixed it so that I could query it like this:
```
$ tfstate-lookup module.webapp.module.ecs_task_roles.aws_iam_role.task_execution_role.name
task-execution-role
```
Please review.
