### PR TITLE
sort names of outputs.

### DIFF
--- a/tfstate/lookup.go
+++ b/tfstate/lookup.go
@@ -8,6 +8,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"github.com/itchyny/gojq"
@@ -179,6 +180,7 @@ func (s *TFState) List() ([]string, error) {
 	for key := range s.state.Outputs {
 		names = append(names, "output."+key)
 	}
+	sort.Strings(names)
 	for _, r := range s.state.Resources {
 		var module string
 		if r.Module != "" {

--- a/tfstate/lookup_test.go
+++ b/tfstate/lookup_test.go
@@ -18,8 +18,8 @@ func init() {
 }
 
 var TestNames = []string{
-	`output.foo`,
 	`output.bar`,
+	`output.foo`,
 	`data.aws_caller_identity.current`,
 	`aws_acm_certificate.main`,
 	`module.logs.aws_cloudwatch_log_group.main["app"]`,


### PR DESCRIPTION
tfstate stores an output section as a JSON object, but Go's map is unordered.
To get a stable result from List(), we must sort the names in the output section.