### PR TITLE
take care of "each" attribute is empty and has multiple instances

### DIFF
--- a/tfstate/lookup_test.go
+++ b/tfstate/lookup_test.go
@@ -27,6 +27,8 @@ var TestNames = []string{
 	`aws_iam_role_policy_attachment.ec2[0]`,
 	`aws_iam_role_policy_attachment.ec2[1]`,
 	`module.webapp.module.ecs_task_roles.aws_iam_role.task_execution_role`,
+	`module.subnets.aws_subnet.main[0]`,
+	`module.subnets.aws_subnet.main[1]`,
 }
 
 var TestSuitesOK = []TestSuite{
@@ -109,6 +111,14 @@ var TestSuitesOK = []TestSuite{
 	TestSuite{
 		Key:    "xxxx.webapp.module.ecs_task_roles.aws_iam_role.task_execution_role",
 		Result: nil,
+	},
+	TestSuite{
+		Key:    "module.subnets.aws_subnet.main[0].cidr_block",
+		Result: "10.11.12.0/22",
+	},
+	TestSuite{
+		Key:    "module.subnets.aws_subnet.main[1].cidr_block",
+		Result: "10.11.15.0/22",
 	},
 }
 

--- a/tfstate/test/terraform.tfstate
+++ b/tfstate/test/terraform.tfstate
@@ -187,6 +187,57 @@
           "private": "bnVsbA=="
         }
       ]
+    },
+    {
+      "module": "module.subnets",
+      "mode": "managed",
+      "type": "aws_subnet",
+      "name": "main",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "index_key": 0,
+          "schema_version": 1,
+          "attributes": {
+            "arn": "arn:aws:ec2:ap-northeast-1:123456789012:subnet/subnet-01234567890123456",
+            "assign_ipv6_address_on_creation": false,
+            "availability_zone": "ap-northeast-1a",
+            "availability_zone_id": "apne1-az4",
+            "cidr_block": "10.11.12.0/22",
+            "id": "subnet-01234567890123456",
+            "ipv6_cidr_block": "",
+            "ipv6_cidr_block_association_id": "",
+            "map_public_ip_on_launch": false,
+            "outpost_arn": "",
+            "owner_id": "012345678901",
+            "tags": {},
+            "timeouts": null,
+            "vpc_id": "vpc-01234567"
+          },
+          "private": "bnVsbA=="
+        },
+        {
+          "index_key": 1,
+          "schema_version": 1,
+          "attributes": {
+            "arn": "arn:aws:ec2:ap-northeast-1:123456789012:subnet/subnet-90123456789012345",
+            "assign_ipv6_address_on_creation": false,
+            "availability_zone": "ap-northeast-1a",
+            "availability_zone_id": "apne1-az4",
+            "cidr_block": "10.11.15.0/22",
+            "id": "subnet-90123456789012345",
+            "ipv6_cidr_block": "",
+            "ipv6_cidr_block_association_id": "",
+            "map_public_ip_on_launch": false,
+            "outpost_arn": "",
+            "owner_id": "012345678901",
+            "tags": {},
+            "timeouts": null,
+            "vpc_id": "vpc-01234567"
+          },
+          "private": "bnVsbA=="
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
I'm using ecspresso and faced a problem that tfstate-lookup could not lookup some resouces in my tfstate.

I found that tfstate-lookup could not work for the resouces which have no "each" attribute and have two or more instance.

<details>
<summary> example resouce </summary>

```json
    {
      "module": "module.subnets",
      "mode": "managed",
      "type": "aws_subnet",
      "name": "main",
      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
      "instances": [
        {
          "index_key": 0,
          "schema_version": 1,
          "attributes": {
            "arn": "arn:aws:ec2:ap-northeast-1:123456789012:subnet/subnet-01234567890123456",
            "assign_ipv6_address_on_creation": false,
            "availability_zone": "ap-northeast-1a",
            "availability_zone_id": "apne1-az4",
            "cidr_block": "10.11.12.0/22",
            "id": "subnet-01234567890123456",
            "ipv6_cidr_block": "",
            "ipv6_cidr_block_association_id": "",
            "map_public_ip_on_launch": false,
            "outpost_arn": "",
            "owner_id": "012345678901",
            "tags": {},
            "timeouts": null,
            "vpc_id": "vpc-01234567"
          },
          "private": "bnVsbA=="
        },
        {
          "index_key": 1,
          "schema_version": 1,
          "attributes": {
            "arn": "arn:aws:ec2:ap-northeast-1:123456789012:subnet/subnet-90123456789012345",
            "assign_ipv6_address_on_creation": false,
            "availability_zone": "ap-northeast-1a",
            "availability_zone_id": "apne1-az4",
            "cidr_block": "10.11.15.0/22",
            "id": "subnet-90123456789012345",
            "ipv6_cidr_block": "",
            "ipv6_cidr_block_association_id": "",
            "map_public_ip_on_launch": false,
            "outpost_arn": "",
            "owner_id": "012345678901",
            "tags": {},
            "timeouts": null,
            "vpc_id": "vpc-01234567"
          },
          "private": "bnVsbA=="
        }
      ]
    }
```
</details>

In this case, this query does not work.
```shell
❯ tfstate-lookup -s tfstate/test/terraform.tfstate 'module.subnets.aws_subnet.main[0].cidr_block'
null

❯ tfstate-lookup -s tfstate/test/terraform.tfstate | grep "module.subnets"
module.subnets.aws_subnet.main

``` 

So, I fixed it.

```shell
❯ make test
go test ./...
?   	github.com/fujiwara/tfstate-lookup/cmd/tfstate-lookup	[no test files]
ok  	github.com/fujiwara/tfstate-lookup/tfstate	(cached)

❯ go build -o tfstate-lookup cmd/tfstate-lookup/main.go

❯ ./tfstate-lookup -s tfstate/test/terraform.tfstate 'module.subnets.aws_subnet.main[0].cidr_block'
10.11.12.0/22

❯ ./tfstate-lookup -s tfstate/test/terraform.tfstate | grep "module.subnets"
module.subnets.aws_subnet.main[0]
module.subnets.aws_subnet.main[1]
```

 Please review 🙇 🙇 