### PR TITLE
Handle "." in "[ ]" as intended

### DIFF
--- a/tfstate/lookup.go
+++ b/tfstate/lookup.go
@@ -210,7 +210,7 @@ func parseAddress(key string) (selectorFunc, string, error) {
 	var selector selectorFunc
 	var query string
 
-	parts := strings.Split(key, ".")
+	parts := makeParts(key)
 	if len(parts) < 2 ||
 		parts[0] == "module" && len(parts) < 4 ||
 		parts[0] == "data" && len(parts) < 3 {
@@ -271,4 +271,28 @@ func noneNil(args ...interface{}) interface{} {
 		}
 	}
 	return nil
+}
+
+func makeParts(key string) []string {
+	var parts []string
+	index := 0
+	inBrackets := false
+	for _, s := range strings.Split(key, "") {
+		if len(parts) < index+1 {
+			parts = append(parts, "")
+		}
+		if s == "[" {
+			inBrackets = true
+		}
+		if s == "]" {
+			inBrackets = false
+		}
+		if s != "." || inBrackets {
+			parts[index] += s
+		}
+		if s == "." && !inBrackets {
+			index++
+		}
+	}
+	return parts
 }

--- a/tfstate/lookup_test.go
+++ b/tfstate/lookup_test.go
@@ -29,6 +29,8 @@ var TestNames = []string{
 	`module.webapp.module.ecs_task_roles.aws_iam_role.task_execution_role`,
 	`module.subnets.aws_subnet.main[0]`,
 	`module.subnets.aws_subnet.main[1]`,
+	`aws_iam_user.users["foo.bar"]`,
+	`aws_iam_user.users["hoge.fuga"]`,
 }
 
 var TestSuitesOK = []TestSuite{
@@ -119,6 +121,14 @@ var TestSuitesOK = []TestSuite{
 	TestSuite{
 		Key:    "module.subnets.aws_subnet.main[1].cidr_block",
 		Result: "10.11.15.0/22",
+	},
+	TestSuite{
+		Key:    `aws_iam_user.users["foo.bar"].name`,
+		Result: "foo.bar",
+	},
+	TestSuite{
+		Key:    `aws_iam_user.users["hoge.fuga"].name`,
+		Result: "hoge.fuga",
 	},
 }
 

--- a/tfstate/test/terraform.tfstate
+++ b/tfstate/test/terraform.tfstate
@@ -238,6 +238,44 @@
           "private": "bnVsbA=="
         }
       ]
+    },
+    {
+      "mode": "managed",
+      "type": "aws_iam_user",
+      "name": "users",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "index_key": "foo.bar",
+          "schema_version": 0,
+          "attributes": {
+            "arn": "arn:aws:iam::xxxxxxxxxxxx:user/foo.bar",
+            "force_destroy": false,
+            "id": "foo.bar",
+            "name": "foo.bar",
+            "path": "/",
+            "permissions_boundary": null,
+            "tags": {},
+            "unique_id": "XXXXXXXXXXXXXXXXXXXXX"
+          },
+          "private": "bnVsbA=="
+        },
+        {
+          "index_key": "hoge.fuga",
+          "schema_version": 0,
+          "attributes": {
+            "arn": "arn:aws:iam::xxxxxxxxxxxx:user/hoge.fuga",
+            "force_destroy": false,
+            "id": "hoge.fuga",
+            "name": "hoge.fuga",
+            "path": "/",
+            "permissions_boundary": null,
+            "tags": {},
+            "unique_id": "XXXXXXXXXXXXXXXXXXXXX"
+          },
+          "private": "bnVsbA=="
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
Hi. Thanks for the great tool.

I've found that if the address includes "." in "[ ]" , `parts := strings.Split(key, ".")` does not work as intended.

For example, if the address is `aws_iam_user.users["foo.bar"]`, `parts[1]` is `users["foo` .

So I wrote `makeParts()` function to handle them as intended.

Please check this.
