### PR TITLE
fix wrong result when lookup key matches only prefix.

### DIFF
--- a/tfstate/lookup.go
+++ b/tfstate/lookup.go
@@ -178,8 +178,10 @@ func (s *TFState) Lookup(key string) (*Object, error) {
 	for name, ins := range s.scanned {
 		if strings.HasPrefix(key, name) {
 			query := strings.TrimPrefix(key, name)
-			attr := &Object{noneNil(ins.Attributes, ins.AttributesFlat)}
-			return attr.Query(query)
+			if strings.HasPrefix(query, ".") || query == "" {
+				attr := &Object{noneNil(ins.Attributes, ins.AttributesFlat)}
+				return attr.Query(query)
+			}
 		}
 	}
 

--- a/tfstate/lookup_test.go
+++ b/tfstate/lookup_test.go
@@ -54,6 +54,10 @@ var TestSuitesOK = []TestSuite{
 		Result: "DNS",
 	},
 	{
+		Key:    "aws_acm_certificate.main2",
+		Result: nil,
+	},
+	{
 		Key:    "aws_acm_certificate.main.validation_method_xxx",
 		Result: nil,
 	},


### PR DESCRIPTION
When a resource `foo.bar` exists, lookup with key `foo.bar2` returned `2`. This result must be `null`.