### PR TITLE
Add GCS remote backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Usage of tfstate-lookup:
         tfstate file path or URL (default "terraform.tfstate")
 ```
 
-Supported URL schemes are http(s), s3 or file.
+Supported URL schemes are http(s), s3, gs or file.
 
 ```console
 $ tfstate-lookup -s .terraform/terraform.tfstate aws_vpc.main.id
@@ -53,7 +53,7 @@ $ tfstate-lookup aws_vpc.main
 }
 ```
 
-A remote state is supported only S3 backend currently.
+A remote state is supported only S3 and GCS backend currently.
 
 ## Usage (Go package)
 

--- a/go.mod
+++ b/go.mod
@@ -3,14 +3,16 @@ module github.com/fujiwara/tfstate-lookup
 go 1.14
 
 require (
+	cloud.google.com/go/storage v1.15.0
 	github.com/aws/aws-sdk-go v1.30.7
 	github.com/fastly/go-utils v0.0.0-20180712184237-d95a45783239 // indirect
-	github.com/google/go-cmp v0.3.1
+	github.com/google/go-cmp v0.5.5
 	github.com/itchyny/gojq v0.9.0
 	github.com/jehiah/go-strftime v0.0.0-20171201141054-1d33003b3869 // indirect
 	github.com/kr/pretty v0.1.0 // indirect
 	github.com/mattn/go-isatty v0.0.12
 	github.com/pkg/errors v0.9.1
 	github.com/tebeka/strftime v0.1.3 // indirect
+	google.golang.org/api v0.45.0
 	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 // indirect
 )

--- a/tfstate/lookup.go
+++ b/tfstate/lookup.go
@@ -158,6 +158,9 @@ func ReadURL(loc string) (*TFState, error) {
 	case "s3":
 		key := strings.TrimPrefix(u.Path, "/")
 		src, err = readS3("", u.Host, key)
+	case "gs":
+		key := strings.TrimPrefix(u.Path, "/")
+		src, err = readGCS(u.Host, key, "")
 	case "file":
 		src, err = os.Open(u.Path)
 	case "":

--- a/tfstate/remote.go
+++ b/tfstate/remote.go
@@ -1,26 +1,9 @@
 package tfstate
 
 import (
-	"context"
 	"fmt"
 	"io"
-	"net/http"
-	"path"
-
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/session"
-	"github.com/aws/aws-sdk-go/service/s3"
-	"github.com/aws/aws-sdk-go/service/s3/s3manager"
 )
-
-func readRemoteState(b *backend, ws string) (io.ReadCloser, error) {
-	switch b.Type {
-	case "s3":
-		return readS3State(b.Config, ws)
-	default:
-		return nil, fmt.Errorf("backend type %s is not supported", b.Type)
-	}
-}
 
 func strp(v interface{}) *string {
 	if v == nil {
@@ -32,56 +15,24 @@ func strp(v interface{}) *string {
 	return nil
 }
 
-func readS3State(config map[string]interface{}, ws string) (io.ReadCloser, error) {
-	region, bucket, key := *strp(config["region"]), *strp(config["bucket"]), *strp(config["key"])
-	if ws != defaultWorkspace {
-		if prefix := strp(config["workspace_key_prefix"]); prefix != nil {
-			key = path.Join(*prefix, ws, key)
-		} else {
-			key = path.Join(defaultWorkspeceKeyPrefix, ws, key)
-		}
+func strpe(v interface{}) *string {
+	empty := ""
+	if v == nil {
+		return &empty
 	}
-	return readS3(region, bucket, key)
+	if vs, ok := v.(string); ok {
+		return &vs
+	}
+	return &empty
 }
 
-func readS3(region, bucket, key string) (io.ReadCloser, error) {
-	var err error
-	if region == "" {
-		region, err = s3manager.GetBucketRegion(
-			context.Background(),
-			session.Must(session.NewSession()),
-			bucket,
-			"",
-		)
-		if err != nil {
-			return nil, err
-		}
+func readRemoteState(b *backend, ws string) (io.ReadCloser, error) {
+	switch b.Type {
+	case "gcs":
+		return readGCSState(b.Config, ws)
+	case "s3":
+		return readS3State(b.Config, ws)
+	default:
+		return nil, fmt.Errorf("backend type %s is not supported", b.Type)
 	}
-	sess, err := session.NewSessionWithOptions(session.Options{
-		Config: aws.Config{
-			Region: aws.String(region),
-		},
-		SharedConfigState: session.SharedConfigEnable,
-	})
-	if err != nil {
-		return nil, err
-	}
-	svc := s3.New(sess)
-
-	result, err := svc.GetObject(&s3.GetObjectInput{
-		Bucket: aws.String(bucket),
-		Key:    aws.String(key),
-	})
-	if err != nil {
-		return nil, err
-	}
-	return result.Body, nil
-}
-
-func readHTTP(u string) (io.ReadCloser, error) {
-	resp, err := http.Get(u)
-	if err != nil {
-		return nil, err
-	}
-	return resp.Body, nil
 }

--- a/tfstate/remote_gcs.go
+++ b/tfstate/remote_gcs.go
@@ -1,0 +1,45 @@
+package tfstate
+
+import (
+	"context"
+	"io"
+	"path"
+
+	"cloud.google.com/go/storage"
+	"google.golang.org/api/option"
+)
+
+func readGCSState(config map[string]interface{}, ws string) (io.ReadCloser, error) {
+	bucket, prefix, credentials := *strp(config["bucket"]), *strpe(config["prefix"]), *strpe(config["credentials"])
+
+	key := path.Join(prefix, ws+".tfstate")
+
+	return readGCS(bucket, key, credentials)
+}
+
+func readGCS(bucket, key, credentials string) (io.ReadCloser, error) {
+	var err error
+
+	ctx := context.Background()
+
+	var client *storage.Client
+	if credentials != "" {
+		client, err = storage.NewClient(ctx, option.WithCredentialsFile(credentials))
+	} else {
+		client, err = storage.NewClient(ctx)
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	bkt := client.Bucket(bucket)
+	obj := bkt.Object(key)
+
+	r, err := obj.NewReader(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return r, nil
+}

--- a/tfstate/remote_http.go
+++ b/tfstate/remote_http.go
@@ -1,0 +1,14 @@
+package tfstate
+
+import (
+	"io"
+	"net/http"
+)
+
+func readHTTP(u string) (io.ReadCloser, error) {
+	resp, err := http.Get(u)
+	if err != nil {
+		return nil, err
+	}
+	return resp.Body, nil
+}

--- a/tfstate/remote_s3.go
+++ b/tfstate/remote_s3.go
@@ -3,7 +3,6 @@ package tfstate
 import (
 	"context"
 	"io"
-	"net/http"
 	"path"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -56,12 +55,4 @@ func readS3(region, bucket, key string) (io.ReadCloser, error) {
 		return nil, err
 	}
 	return result.Body, nil
-}
-
-func readHTTP(u string) (io.ReadCloser, error) {
-	resp, err := http.Get(u)
-	if err != nil {
-		return nil, err
-	}
-	return resp.Body, nil
 }

--- a/tfstate/remote_s3.go
+++ b/tfstate/remote_s3.go
@@ -1,0 +1,67 @@
+package tfstate
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"path"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/aws/aws-sdk-go/service/s3/s3manager"
+)
+
+func readS3State(config map[string]interface{}, ws string) (io.ReadCloser, error) {
+	region, bucket, key := *strp(config["region"]), *strp(config["bucket"]), *strp(config["key"])
+	if ws != defaultWorkspace {
+		if prefix := strp(config["workspace_key_prefix"]); prefix != nil {
+			key = path.Join(*prefix, ws, key)
+		} else {
+			key = path.Join(defaultWorkspeceKeyPrefix, ws, key)
+		}
+	}
+	return readS3(region, bucket, key)
+}
+
+func readS3(region, bucket, key string) (io.ReadCloser, error) {
+	var err error
+	if region == "" {
+		region, err = s3manager.GetBucketRegion(
+			context.Background(),
+			session.Must(session.NewSession()),
+			bucket,
+			"",
+		)
+		if err != nil {
+			return nil, err
+		}
+	}
+	sess, err := session.NewSessionWithOptions(session.Options{
+		Config: aws.Config{
+			Region: aws.String(region),
+		},
+		SharedConfigState: session.SharedConfigEnable,
+	})
+	if err != nil {
+		return nil, err
+	}
+	svc := s3.New(sess)
+
+	result, err := svc.GetObject(&s3.GetObjectInput{
+		Bucket: aws.String(bucket),
+		Key:    aws.String(key),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return result.Body, nil
+}
+
+func readHTTP(u string) (io.ReadCloser, error) {
+	resp, err := http.Get(u)
+	if err != nil {
+		return nil, err
+	}
+	return resp.Body, nil
+}


### PR DESCRIPTION
This is a GCS backend. Now it is possible to use `terraform.tfstate` file with `"type": "gcs"` backend. Additionaly it supports `gs://` schema.

This PR should solve #13 