### PR TITLE
feat: Support AWS STS Assume Role

### DIFF
--- a/tfstate/lookup.go
+++ b/tfstate/lookup.go
@@ -157,7 +157,7 @@ func ReadURL(loc string) (*TFState, error) {
 		src, err = readHTTP(u.String())
 	case "s3":
 		key := strings.TrimPrefix(u.Path, "/")
-		src, err = readS3("", "", u.Host, key)
+		src, err = readS3(u.Host, key, s3Option{})
 	case "gs":
 		key := strings.TrimPrefix(u.Path, "/")
 		src, err = readGCS(u.Host, key, "")

--- a/tfstate/lookup.go
+++ b/tfstate/lookup.go
@@ -157,7 +157,7 @@ func ReadURL(loc string) (*TFState, error) {
 		src, err = readHTTP(u.String())
 	case "s3":
 		key := strings.TrimPrefix(u.Path, "/")
-		src, err = readS3("", u.Host, key)
+		src, err = readS3("", "", u.Host, key)
 	case "gs":
 		key := strings.TrimPrefix(u.Path, "/")
 		src, err = readGCS(u.Host, key, "")

--- a/tfstate/remote_s3.go
+++ b/tfstate/remote_s3.go
@@ -13,8 +13,13 @@ import (
 	"github.com/aws/aws-sdk-go/service/s3/s3manager"
 )
 
+type s3Option struct {
+	region   string
+	role_arn string
+}
+
 func readS3State(config map[string]interface{}, ws string) (io.ReadCloser, error) {
-	role, region, bucket, key := *strpe(config["role_arn"]), *strpe(config["region"]), *strpe(config["bucket"]), *strpe(config["key"])
+	bucket, key := *strpe(config["bucket"]), *strpe(config["key"])
 	if ws != defaultWorkspace {
 		if prefix := strp(config["workspace_key_prefix"]); prefix != nil {
 			key = path.Join(*prefix, ws, key)
@@ -22,13 +27,17 @@ func readS3State(config map[string]interface{}, ws string) (io.ReadCloser, error
 			key = path.Join(defaultWorkspeceKeyPrefix, ws, key)
 		}
 	}
-	return readS3(role, region, bucket, key)
+	opt := s3Option{
+		region:   *strpe(config["region"]),
+		role_arn: *strpe(config["role_arn"]),
+	}
+	return readS3(bucket, key, opt)
 }
 
-func readS3(role, region, bucket, key string) (io.ReadCloser, error) {
+func readS3(bucket, key string, opt s3Option) (io.ReadCloser, error) {
 	var err error
-	if region == "" {
-		region, err = s3manager.GetBucketRegion(
+	if opt.region == "" {
+		opt.region, err = s3manager.GetBucketRegion(
 			context.Background(),
 			session.Must(session.NewSession()),
 			bucket,
@@ -40,7 +49,7 @@ func readS3(role, region, bucket, key string) (io.ReadCloser, error) {
 	}
 	sess, err := session.NewSessionWithOptions(session.Options{
 		Config: aws.Config{
-			Region: aws.String(region),
+			Region: aws.String(opt.region),
 		},
 		SharedConfigState: session.SharedConfigEnable,
 	})
@@ -48,8 +57,8 @@ func readS3(role, region, bucket, key string) (io.ReadCloser, error) {
 		return nil, err
 	}
 	cfg := &aws.Config{}
-	if role != "" {
-		arn, err := arn.Parse(role)
+	if opt.role_arn != "" {
+		arn, err := arn.Parse(opt.role_arn)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Terraform allows you to specify a role_arn argument that specifies an AssumeRole for your S3 remote backend.

See also: https://www.terraform.io/docs/language/settings/backends/s3.html#role_arn

I need an AssumeRole for my project, so I would be grateful if you could support role_arn!