### PR TITLE
fix GetBucketRegion auto detection

### DIFF
--- a/tfstate/export_test.go
+++ b/tfstate/export_test.go
@@ -1,0 +1,5 @@
+package tfstate
+
+var (
+	GetBucketRegion = getBucketRegion
+)

--- a/tfstate/remote_s3.go
+++ b/tfstate/remote_s3.go
@@ -37,12 +37,7 @@ func readS3State(config map[string]interface{}, ws string) (io.ReadCloser, error
 func readS3(bucket, key string, opt s3Option) (io.ReadCloser, error) {
 	var err error
 	if opt.region == "" {
-		opt.region, err = s3manager.GetBucketRegion(
-			context.Background(),
-			session.Must(session.NewSession()),
-			bucket,
-			"",
-		)
+		opt.region, err = getBucketRegion(bucket)
 		if err != nil {
 			return nil, err
 		}
@@ -75,4 +70,13 @@ func readS3(bucket, key string, opt s3Option) (io.ReadCloser, error) {
 		return nil, err
 	}
 	return result.Body, nil
+}
+
+func getBucketRegion(bucket string) (string, error) {
+	return s3manager.GetBucketRegion(
+		context.Background(),
+		session.Must(session.NewSession()),
+		bucket,
+		"us-east-1",
+	)
 }

--- a/tfstate/remote_s3_test.go
+++ b/tfstate/remote_s3_test.go
@@ -1,0 +1,33 @@
+package tfstate_test
+
+import (
+	"testing"
+
+	"github.com/fujiwara/tfstate-lookup/tfstate"
+)
+
+var testBuckets = []struct {
+	bucket string
+	region string
+}{
+	{
+		bucket: "tfstate-lookup",
+		region: "us-east-1",
+	},
+	{
+		bucket: "tfstate-lookup-oregon",
+		region: "us-west-2",
+	},
+}
+
+func TestBucketRegion(t *testing.T) {
+	for _, b := range testBuckets {
+		region, err := tfstate.GetBucketRegion(b.bucket)
+		if err != nil {
+			t.Error(err)
+		}
+		if b.region != region {
+			t.Errorf("unexpected region of %s. expected %s, got %s", b.bucket, b.region, region)
+		}
+	}
+}


### PR DESCRIPTION
If region hint is empty, failed to get bucket region when AWS_REGION is not set.