### PR TITLE
fix: avoid panic if referring the attributes that its contains characters other than jq's identifier

### DIFF
--- a/tfstate/lookup_test.go
+++ b/tfstate/lookup_test.go
@@ -40,6 +40,7 @@ var TestNames = []string{
 	`data.aws_lb_target_group.app["dev2"]`,
 	`data.aws_lb_target_group.app["dev3"]`,
 	`data.terraform_remote_state.remote`,
+	`data.terraform_remote_state.hyphenated-id`,
 }
 
 var TestSuitesOK = []TestSuite{
@@ -166,6 +167,10 @@ var TestSuitesOK = []TestSuite{
 	{
 		Key:    `aws_iam_user.user["me"].arn`,
 		Result: `arn:aws:iam::xxxxxxxxxxxx:user/me`,
+	},
+	{
+		Key:    `data.terraform_remote_state.hyphenated-id.outputs.repository-uri`,
+		Result: `123456789012.dkr.ecr.ap-northeast-1.amazonaws.com/app`,
 	},
 }
 

--- a/tfstate/test/terraform.tfstate
+++ b/tfstate/test/terraform.tfstate
@@ -511,6 +511,34 @@
       "name": "example",
       "provider": "provider.aws",
       "instances": []
+    },
+    {
+      "mode": "data",
+      "type": "terraform_remote_state",
+      "name": "hyphenated-id",
+      "provider": "provider[\"terraform.io/builtin/terraform\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "backend": "local",
+            "defaults": null,
+            "outputs": {
+              "value": {
+                "repository-uri": "123456789012.dkr.ecr.ap-northeast-1.amazonaws.com/app"
+              },
+              "type": [
+                "object",
+                {
+                  "repository-uri": "string"
+                }
+              ]
+            },
+            "workspace": null
+          },
+          "sensitive_attributes": []
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
# Problem

Terraform resources' name may contain `-` (hyphen) and [it is valid](https://www.terraform.io/docs/language/syntax/configuration.html#identifiers).

However, [jq's identifier-like characters](https://stedolan.github.io/jq/manual/#ObjectIdentifier-Index:.foo,.foo.bar) do not contain `-`.

So if tfstate-lookup passed a query like `.outputs.repository-arn`, it receives an error like `function not defined: uri/0` from gojq and panics.

# Solution

Always passing valid jq query surrounding non-identifier characters with `[""]`.