### PR TITLE
Support encryption_key in GCS backend

### DIFF
--- a/tfstate/lookup.go
+++ b/tfstate/lookup.go
@@ -173,7 +173,7 @@ func ReadURL(loc string) (*TFState, error) {
 		src, err = readS3(u.Host, key, s3Option{})
 	case "gs":
 		key := strings.TrimPrefix(u.Path, "/")
-		src, err = readGCS(u.Host, key, "")
+		src, err = readGCS(u.Host, key, "", os.Getenv("GOOGLE_ENCRYPTION_KEY"))
 	case "azurerm":
 		split := strings.Split(u.Path, "/")
 		src, err = readAzureRM(u.Host, split[1], split[2], split[3], azureRMOption{})

--- a/tfstate/remote_gcs.go
+++ b/tfstate/remote_gcs.go
@@ -2,6 +2,7 @@ package tfstate
 
 import (
 	"context"
+	"encoding/base64"
 	"io"
 	"path"
 
@@ -10,14 +11,14 @@ import (
 )
 
 func readGCSState(config map[string]interface{}, ws string) (io.ReadCloser, error) {
-	bucket, prefix, credentials := *strp(config["bucket"]), *strpe(config["prefix"]), *strpe(config["credentials"])
+	bucket, prefix, credentials, encryption_key := *strp(config["bucket"]), *strpe(config["prefix"]), *strpe(config["credentials"]), *strpe(config["encryption_key"])
 
 	key := path.Join(prefix, ws+".tfstate")
 
-	return readGCS(bucket, key, credentials)
+	return readGCS(bucket, key, credentials, encryption_key)
 }
 
-func readGCS(bucket, key, credentials string) (io.ReadCloser, error) {
+func readGCS(bucket, key, credentials, encryption_key string) (io.ReadCloser, error) {
 	var err error
 
 	ctx := context.Background()
@@ -36,7 +37,15 @@ func readGCS(bucket, key, credentials string) (io.ReadCloser, error) {
 	bkt := client.Bucket(bucket)
 	obj := bkt.Object(key)
 
-	r, err := obj.NewReader(ctx)
+	var r *storage.Reader
+
+	if encryption_key != "" {
+		decodedKey, _ := base64.StdEncoding.DecodeString(encryption_key)
+		r, err = obj.Key(decodedKey).NewReader(ctx)
+	} else {
+		r, err = obj.NewReader(ctx)
+	}
+
 	if err != nil {
 		return nil, err
 	}

--- a/tfstate/remote_gcs.go
+++ b/tfstate/remote_gcs.go
@@ -11,7 +11,10 @@ import (
 )
 
 func readGCSState(config map[string]interface{}, ws string) (io.ReadCloser, error) {
-	bucket, prefix, credentials, encryption_key := *strp(config["bucket"]), *strpe(config["prefix"]), *strpe(config["credentials"]), *strpe(config["encryption_key"])
+	bucket := *strp(config["bucket"])
+	prefix := *strpe(config["prefix"])
+	credentials := *strpe(config["credentials"])
+	encryption_key := *strpe(config["encryption_key"])
 
 	key := path.Join(prefix, ws+".tfstate")
 


### PR DESCRIPTION
Hi, 

This patch allows to use `encryption_key` option for GCS backend: https://www.terraform.io/language/settings/backends/gcs#encryption_key

It might be stored in `.terraform/terraform.state` file as `backend.config.encryption_key` or in `GOOGLE_ENCRYPTION_KEY` environment variable (the same feature that original Terraform has).

Without this patch I am unable to decode encrypted state stored on the bucket.
