### PR TITLE
Generate a single FuncMap from multiple locations

### DIFF
--- a/tfstate/funcs_test.go
+++ b/tfstate/funcs_test.go
@@ -53,3 +53,24 @@ func TestMustFuncMapF(t *testing.T) {
 	}()
 	fn("data.aws_caller_identity.current.xxx")
 }
+
+func TestMustFuncMapWithNames(t *testing.T) {
+	funcMap := tfstate.MustFuncMapWithNames("myfunc", []string{"./test/outputs-foo.tfstate", "./test/outputs-bar.tfstate"})
+	fn := funcMap["myfunc"].(func(string) string)
+	if fn == nil {
+		t.Error("no function")
+	}
+	if attr := fn("output.foo"); attr != "FOO" {
+		t.Errorf("unexpected foo: %s", attr)
+	}
+	if attr := fn("output.bar[1]"); attr != "B" {
+		t.Errorf("unexpected bar: %s", attr)
+	}
+	defer func() {
+		err := recover()
+		if err == nil {
+			t.Error("must be panic")
+		}
+	}()
+	fn("output.baz")
+}

--- a/tfstate/test/outputs-bar.tfstate
+++ b/tfstate/test/outputs-bar.tfstate
@@ -1,0 +1,12 @@
+{
+  "version": 4,
+  "terraform_version": "0.12.16",
+  "serial": 173,
+  "lineage": "43123af7-7fbd-4ba4-be20-e018c8a96894",
+  "outputs": {
+    "bar": {
+      "value": ["A", "B", "C"],
+      "type": ["tuple", ["string", "string", "string"]]
+    }
+  }
+}

--- a/tfstate/test/outputs-foo.tfstate
+++ b/tfstate/test/outputs-foo.tfstate
@@ -1,0 +1,12 @@
+{
+  "version": 4,
+  "terraform_version": "0.12.16",
+  "serial": 173,
+  "lineage": "1091f281-5d84-40e4-815c-bd42137e0aee",
+  "outputs": {
+    "foo": {
+      "value": "FOO",
+      "type": "string"
+    }
+  }
+}


### PR DESCRIPTION
### Motivation

Thank you for developing and maintain powerful and great tools.

For modularity, my team splits into multiple tfstates for example `network.tfstate`, `iam.tfstate` and so on.
Thus, with ecspresso tfstate plugin, we want to load states from multiple locations.

For example:
```
region: ap-northeast-1
cluster: default
service: test
service_definition: ecs-service-def.json
task_definition: ecs-task-def.json
plugins:
  - name: tfstate
    config:
      paths:
        - foo.tfstate
        - bar.tfstate
```

To achieve this, we need that tfstate-lookup can generate a single FuncMap from multiple locations.

### Method

Add `FuncMapWithNames` and `MustFuncMapWithNames`, that can merge multiple tfstate into single FuncMap.