### PR TITLE
Improve quoteJQQuery reliability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,9 @@
 # Test binary, built with `go test -c`
 *.test
 
+# Binary built with `go build`
+cmd/tfstate-lookup/tfstate-lookup
+
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
 

--- a/tfstate/lookup.go
+++ b/tfstate/lookup.go
@@ -244,7 +244,7 @@ func (s *TFState) Lookup(key string) (*Object, error) {
 // quoteJQQuery does it.
 func quoteJQQuery(query string) string {
 	splitRegex := regexp.MustCompile(`[.\[\]]`)
-	digitRegex := regexp.MustCompile(`^[0-9]+$`)
+	indexRegex := regexp.MustCompile(`^-?[0-9]+$`)
 	parts := splitRegex.Split(query, -1)
 	parts_coalesced := make([]string, 0, len(parts))
 
@@ -259,7 +259,7 @@ func quoteJQQuery(query string) string {
 
 	for _, part := range parts_coalesced {
 		builder.WriteByte('[')
-		if digitRegex.MatchString(part) {
+		if indexRegex.MatchString(part) {
 			builder.WriteString(part)
 		} else {
 			if !strings.HasPrefix(part, `"`) {
@@ -274,7 +274,6 @@ func quoteJQQuery(query string) string {
 		}
 		builder.WriteByte(']')
 	}
-
 	return builder.String()
 }
 

--- a/tfstate/lookup_test.go
+++ b/tfstate/lookup_test.go
@@ -25,6 +25,7 @@ func init() {
 var TestNames = []string{
 	`output.bar`,
 	`output.foo`,
+	`output.dash-tuple`,
 	`data.aws_caller_identity.current`,
 	`aws_acm_certificate.main`,
 	`module.logs.aws_cloudwatch_log_group.main`,
@@ -181,6 +182,10 @@ var TestSuitesOK = []TestSuite{
 	{
 		Key:    `data.terraform_remote_state.hyphenated-id.outputs.repository-uri`,
 		Result: `123456789012.dkr.ecr.ap-northeast-1.amazonaws.com/app`,
+	},
+	{
+		Key:    `output.dash-tuple[1]`,
+		Result: float64(2),
 	},
 }
 

--- a/tfstate/lookup_test.go
+++ b/tfstate/lookup_test.go
@@ -187,6 +187,10 @@ var TestSuitesOK = []TestSuite{
 		Key:    `output.dash-tuple[1]`,
 		Result: float64(2),
 	},
+	{
+		Key:    `output.dash-tuple[-1]`,
+		Result: float64(1),
+	},
 }
 
 func testLookupState(t *testing.T, state *tfstate.TFState) {

--- a/tfstate/test/terraform.tfstate
+++ b/tfstate/test/terraform.tfstate
@@ -22,6 +22,21 @@
           "string"
         ]
       ]
+    },
+    "dash-tuple": {
+      "value": [
+        3,
+        2,
+        1
+      ],
+      "type": [
+        "tuple",
+        [
+          "number",
+          "number",
+          "number"
+        ]
+      ]
     }
   },
   "resources": [


### PR DESCRIPTION
I have found a bug when looking up values of objects that have dashes in the name, while being the first key after the scanned object name. In this PR, a few tests were added to replicate that issue as well as a fix for quoteJQQuery function, that was the source of the problem. The logic of quoteJQQuery was simplified to extract all indices and quote them depending on type, numbers with [] and all strings with [""]. Also, the behavior of quoteJQQuery was unified to run the same on queries with and without dashes, which improves the transparency of the query mechanism.