### PR TITLE
Embed the original error into a new error.

### DIFF
--- a/tfstate/lookup.go
+++ b/tfstate/lookup.go
@@ -198,7 +198,7 @@ func ReadURL(ctx context.Context, loc string) (*TFState, error) {
 		err = fmt.Errorf("URL scheme %s is not supported", u.Scheme)
 	}
 	if err != nil {
-		return nil, fmt.Errorf("failed to read tfstate from %s", u.String())
+		return nil, fmt.Errorf("failed to read tfstate from %s: %w", u.String(), err)
 	}
 	defer src.Close()
 	return Read(ctx, src)


### PR DESCRIPTION
This pull request includes an improvement to error handling in the `ReadURL` function within the `tfstate/lookup.go` file. The change enhances the error message by including the original error that caused the failure.
