### PR TITLE
Bump minimum Go version to 1.25 and update CI

### DIFF
--- a/.github/workflows/tagpr-release.yml
+++ b/.github/workflows/tagpr-release.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v5
         with:
           ref: ${{ inputs.tag || github.ref }}
-      - uses: Songmu/tagpr@b3fb89424646b06c8aa460f50307c60b6a541425 # v1
+      - uses: Songmu/tagpr@9d0f650553240dab1fa907eca27e3fd5b586e538 # v1.18.1
         id: tagpr
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -31,7 +31,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
-          go-version: "1.24"
+          go-version: "1.26"
         if: ${{ steps.tagpr.outputs.tag != '' || github.event_name == 'workflow_dispatch' }}
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@ec59f474b9834571250b370d4735c50f8e2d1e29 # v7.0.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,8 +5,8 @@ jobs:
     strategy:
       matrix:
         go:
-          - "1.24"
           - "1.25"
+          - "1.26"
     name: Build
     runs-on: ubuntu-latest
     steps:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/fujiwara/tfstate-lookup
 
-go 1.24.5
+go 1.25
 
 require (
 	cloud.google.com/go/storage v1.59.2


### PR DESCRIPTION
## Summary
- Set minimum Go version to 1.25 (`go.mod`)
- Update test matrix to 1.25 / 1.26
- Use Go 1.26 for release builds
- Update `Songmu/tagpr` to v1.18.1 (SHA pinned)

🤖 Generated with [Claude Code](https://claude.com/claude-code)