### PR TITLE
Add SetOverrides + Empty for caller-supplied state values

### DIFF
--- a/tfstate/lookup.go
+++ b/tfstate/lookup.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"maps"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -74,6 +75,13 @@ type TFState struct {
 	scanned map[string]any
 	groups  map[string]any // Parent keys for indexed resources (count/for_each)
 	once    sync.Once
+
+	// overrides holds external values that Lookup consults before
+	// falling through to the underlying state. Populated via
+	// SetOverrides. Protected by overridesMu because SetOverrides may
+	// be called after construction while Lookup is running.
+	overridesMu sync.RWMutex
+	overrides   map[string]any
 }
 
 type tfstate struct {
@@ -120,6 +128,18 @@ type instance struct {
 	Private        string          `json:"private"`
 
 	data any
+}
+
+// Empty returns a TFState with no underlying tfstate source. Useful when
+// the caller wants to populate the state entirely via SetOverrides — e.g.
+// an orchestrator that already has all relevant resource values in hand
+// and does not want a tfstate file as a source.
+//
+// A TFState returned by Empty satisfies the same interface as one
+// returned by Read / ReadFile / ReadURL; Lookup, FuncMap, Dump, and List
+// all work and simply return empty/miss until SetOverrides is called.
+func Empty() *TFState {
+	return &TFState{state: tfstate{Version: StateVersion}}
 }
 
 // Read reads a tfstate from io.Reader
@@ -241,30 +261,68 @@ func ReadURL(ctx context.Context, loc string, opts ...ReadURLOption) (*TFState, 
 	return Read(ctx, src)
 }
 
+// SetOverrides replaces this state's override map. Each key is a
+// resource-level address (`aws_foo.bar`, `output.foo`,
+// `module.m.aws_foo.bar[0]`) — i.e. an address at the same granularity
+// as the entries the scanner produces from a real tfstate file. The
+// value is the resource's full attributes (typically map[string]any),
+// or for outputs the output value itself.
+//
+// Lookup consults overrides at both the exact-match and longest-prefix
+// stages: a request for `aws_foo.bar.value` finds the `aws_foo.bar`
+// override and navigates `.value` via the same jq path the underlying
+// state uses. Overrides win over the underlying state on both kinds of
+// match.
+//
+// Pass nil or an empty map to clear. SetOverrides is safe to call
+// concurrently with Lookup.
+func (s *TFState) SetOverrides(overrides map[string]any) {
+	s.overridesMu.Lock()
+	defer s.overridesMu.Unlock()
+	if len(overrides) == 0 {
+		s.overrides = nil
+		return
+	}
+	cp := make(map[string]any, len(overrides))
+	maps.Copy(cp, overrides)
+	s.overrides = cp
+}
+
 // Lookup lookups attributes of the specified key in tfstate
 func (s *TFState) Lookup(key string) (*Object, error) {
 	s.once.Do(s.scan)
 
-	// First, check for exact match in individual instances
+	s.overridesMu.RLock()
+	defer s.overridesMu.RUnlock()
+
+	// Exact match. Overrides win over the underlying state.
+	if found, ok := s.overrides[key]; ok {
+		return &Object{found}, nil
+	}
 	if found, ok := s.scanned[key]; ok {
 		return &Object{found}, nil
 	}
-
-	// Then, check for exact match in groups (parent keys)
 	if found, ok := s.groups[key]; ok {
 		return &Object{found}, nil
 	}
 
-	// Finally, look for longest prefix match in individual instances
+	// Longest prefix match across overrides + scanned. Overrides are
+	// iterated first so they win on a length tie; otherwise the longer
+	// of the two prefixes wins. Non-boundary prefixes (e.g. "publican"
+	// against "public") are filtered out below by the suffix-prefix
+	// check, which only accepts `.` or `[` as separators.
 	var found any
 	var foundName string
+	for name, ins := range s.overrides {
+		if strings.HasPrefix(key, name) && len(name) > len(foundName) {
+			found = ins
+			foundName = name
+		}
+	}
 	for name, ins := range s.scanned {
-		if strings.HasPrefix(key, name) {
-			// longest match
-			if len(foundName) < len(name) {
-				found = ins
-				foundName = name
-			}
+		if strings.HasPrefix(key, name) && len(name) > len(foundName) {
+			found = ins
+			foundName = name
 		}
 	}
 	if foundName == "" {

--- a/tfstate/overrides_test.go
+++ b/tfstate/overrides_test.go
@@ -1,0 +1,153 @@
+package tfstate_test
+
+import (
+	"context"
+	"os"
+	"reflect"
+	"testing"
+
+	"github.com/fujiwara/tfstate-lookup/tfstate"
+)
+
+// TestOverridesEmpty exercises a TFState that has no underlying source —
+// the only data it knows comes from SetOverrides.
+func TestOverridesEmpty(t *testing.T) {
+	s := tfstate.Empty()
+	s.SetOverrides(map[string]any{
+		"aws_iam_role.task.arn":           "arn:aws:iam::123:role/task",
+		"aws_ssm_parameter.new_parameter": map[string]any{"name": "/np", "value": "secret"},
+		"output.list":                     []any{"a", "b", "c"},
+		"output.flag":                     true,
+		"output.count":                    float64(42),
+	})
+
+	tests := []struct {
+		key  string
+		want any
+	}{
+		{"aws_iam_role.task.arn", "arn:aws:iam::123:role/task"},
+		{"aws_ssm_parameter.new_parameter.name", "/np"},
+		{"aws_ssm_parameter.new_parameter.value", "secret"},
+		{"output.list[0]", "a"},
+		{"output.list[2]", "c"},
+		{"output.flag", true},
+		{"output.count", float64(42)},
+	}
+	for _, tc := range tests {
+		t.Run(tc.key, func(t *testing.T) {
+			obj, err := s.Lookup(tc.key)
+			if err != nil {
+				t.Fatalf("Lookup(%q): %v", tc.key, err)
+			}
+			if obj == nil || obj.Value == nil {
+				t.Fatalf("Lookup(%q): nil result", tc.key)
+			}
+			if !reflect.DeepEqual(obj.Value, tc.want) {
+				t.Errorf("Lookup(%q) = %#v, want %#v", tc.key, obj.Value, tc.want)
+			}
+		})
+	}
+}
+
+// TestOverridesPrefersOverrideOverState confirms that overrides win over
+// whatever the underlying tfstate file says. Using the real example state
+// fixture: bar's actual output value is "barbar"; an override of "BAR"
+// must be returned instead.
+func TestOverridesPrefersOverrideOverState(t *testing.T) {
+	ctx := context.Background()
+	f, err := os.Open("test/terraform.tfstate")
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer f.Close()
+	s, err := tfstate.Read(ctx, f)
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+
+	// Sanity: without overrides, output.bar is whatever the fixture says.
+	before, err := s.Lookup("output.bar")
+	if err != nil {
+		t.Fatalf("Lookup before: %v", err)
+	}
+	if before == nil || before.Value == nil {
+		t.Fatal("expected output.bar to be present in fixture")
+	}
+
+	s.SetOverrides(map[string]any{"output.bar": "OVERRIDDEN"})
+
+	after, err := s.Lookup("output.bar")
+	if err != nil {
+		t.Fatalf("Lookup after: %v", err)
+	}
+	if got := after.Value; got != "OVERRIDDEN" {
+		t.Errorf("Lookup(output.bar) = %#v, want OVERRIDDEN", got)
+	}
+
+	// Other keys still resolve from the underlying state.
+	other, err := s.Lookup("output.foo")
+	if err != nil {
+		t.Fatalf("Lookup other: %v", err)
+	}
+	if other == nil || other.Value == nil {
+		t.Errorf("non-overridden key fell through to empty result")
+	}
+
+	// Clearing overrides restores the original behaviour.
+	s.SetOverrides(nil)
+	restored, err := s.Lookup("output.bar")
+	if err != nil {
+		t.Fatalf("Lookup after clear: %v", err)
+	}
+	if !reflect.DeepEqual(restored.Value, before.Value) {
+		t.Errorf("after clear: got %#v, want %#v", restored.Value, before.Value)
+	}
+}
+
+// TestOverridesPrefixBoundary ensures a prefix override only matches when
+// the suffix begins with a syntactic boundary (`.` or `[`), so that a
+// key like "aws_subnet.publican" does not silently use an override for
+// "aws_subnet.public".
+func TestOverridesPrefixBoundary(t *testing.T) {
+	s := tfstate.Empty()
+	s.SetOverrides(map[string]any{
+		"aws_subnet.public": map[string]any{"a": "X"},
+	})
+
+	hit, err := s.Lookup("aws_subnet.public.a")
+	if err != nil {
+		t.Fatalf("Lookup match: %v", err)
+	}
+	if hit == nil || hit.Value != "X" {
+		t.Errorf("expected boundary-prefix match to navigate, got %#v", hit)
+	}
+
+	miss, err := s.Lookup("aws_subnet.publican")
+	if err != nil {
+		t.Fatalf("Lookup non-boundary: %v", err)
+	}
+	// On an Empty state with no matching override, Lookup returns
+	// &Object{} (Value == nil) rather than an error — same as a normal
+	// state miss.
+	if miss != nil && miss.Value != nil {
+		t.Errorf("expected non-boundary prefix to miss, got %#v", miss.Value)
+	}
+}
+
+// TestOverridesExactBeatsPrefix confirms that an exact key wins even when
+// a shorter prefix also matches the requested address.
+func TestOverridesExactBeatsPrefix(t *testing.T) {
+	s := tfstate.Empty()
+	s.SetOverrides(map[string]any{
+		"aws_resource.foo":     map[string]any{"bar": "from-prefix"},
+		"aws_resource.foo.bar": "from-exact",
+	})
+
+	obj, err := s.Lookup("aws_resource.foo.bar")
+	if err != nil {
+		t.Fatalf("Lookup: %v", err)
+	}
+	if obj == nil || obj.Value != "from-exact" {
+		t.Errorf("exact match did not win: %#v", obj)
+	}
+}


### PR DESCRIPTION
## Summary

Add a small override channel on `TFState`:

- `func (s *TFState) SetOverrides(map[string]any)` — install a set of caller-supplied values keyed by resource-level addresses (e.g. `aws_foo.bar`, `output.foo`).
- `func Empty() *TFState` — construct a `TFState` with no underlying file/URL, for callers that want to drive lookups entirely from `SetOverrides`.

`Lookup` consults overrides first at both the exact-match and longest-prefix-match stages. Nested attribute access (`aws_foo.bar.value`, `aws_foo.bar.tags.env`, …) keeps working through the existing prefix + gojq navigation, so a caller can inject a whole resource and still satisfy any nested lookup against it.

## Why

Tools that orchestrate Terraform state (e.g. a Terraform provider that wraps ecspresso) need a way to push values they have in hand into the lookup table without going through a tfstate file. The state file is by definition one apply behind, so the first run after a fresh resource is created never works through it alone. Overrides solve that without changing the file-based path for everyone else.

Overrides win over the underlying state on both exact and prefix matches by design — callers opt into overrides precisely when they have fresher values than the file. Keys not in the override map fall through to the underlying state as before.

## Test plan

- [x] `TestOverridesEmpty` — `Empty()` returns a usable, empty `TFState`
- [x] `TestOverridesPrefersOverrideOverState` — override beats the underlying file at exact match
- [x] `TestOverridesPrefixBoundary` — overrides participate in longest-prefix-match correctly
- [x] `TestOverridesExactBeatsPrefix` — an exact match in either set still beats a prefix match
- [x] Existing tests still pass (no changes to file-loading or jq paths)