### PR TITLE
Add DiscardScannedState to drop the underlying tfstate

### DIFF
--- a/tfstate/lookup.go
+++ b/tfstate/lookup.go
@@ -261,6 +261,30 @@ func ReadURL(ctx context.Context, loc string, opts ...ReadURLOption) (*TFState, 
 	return Read(ctx, src)
 }
 
+// DiscardScannedState drops anything that has already been scanned
+// from the underlying tfstate (path / url / io.Reader) and prevents
+// any future lazy scan from populating it. After this call, Lookup
+// resolves keys from the override map only: a key that is absent
+// from overrides surfaces as a miss, the same as on a freshly
+// Empty() state.
+//
+// This is the right knob for callers that supply every relevant
+// value through SetOverrides — e.g. a Terraform provider wrapping
+// ecspresso — and want missing overrides to fail fast instead of
+// being silently filled in from a possibly-stale tfstate file.
+//
+// One-shot operation: the scanned data is freed and cannot be
+// brought back without re-Read'ing the state.
+func (s *TFState) DiscardScannedState() {
+	s.overridesMu.Lock()
+	defer s.overridesMu.Unlock()
+	// Mark the lazy scanner as already-run so Lookup's s.once.Do(s.scan)
+	// becomes a no-op, then drop any data a prior Lookup already loaded.
+	s.once.Do(func() {})
+	s.scanned = nil
+	s.groups = nil
+}
+
 // SetOverrides replaces this state's override map. Each key is a
 // resource-level address (`aws_foo.bar`, `output.foo`,
 // `module.m.aws_foo.bar[0]`) — i.e. an address at the same granularity

--- a/tfstate/overrides_test.go
+++ b/tfstate/overrides_test.go
@@ -151,3 +151,79 @@ func TestOverridesExactBeatsPrefix(t *testing.T) {
 		t.Errorf("exact match did not win: %#v", obj)
 	}
 }
+
+// TestDiscardScannedState verifies that DiscardScannedState drops the
+// underlying tfstate so Lookup serves keys from overrides only.
+func TestDiscardScannedState(t *testing.T) {
+	ctx := context.Background()
+	f, err := os.Open("test/terraform.tfstate")
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer f.Close()
+	s, err := tfstate.Read(ctx, f)
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+
+	// Sanity: output.bar exists in the fixture before discarding.
+	before, err := s.Lookup("output.bar")
+	if err != nil {
+		t.Fatalf("Lookup before: %v", err)
+	}
+	if before == nil || before.Value == nil {
+		t.Fatal("expected output.bar to be present in fixture")
+	}
+
+	s.SetOverrides(map[string]any{
+		"output.bar": "OVERRIDDEN",
+	})
+	s.DiscardScannedState()
+
+	// Overridden key still resolves to the override value.
+	got, err := s.Lookup("output.bar")
+	if err != nil {
+		t.Fatalf("Lookup override: %v", err)
+	}
+	if got.Value != "OVERRIDDEN" {
+		t.Errorf("Lookup(output.bar) = %#v, want OVERRIDDEN", got.Value)
+	}
+
+	// A different key that does exist in the fixture must no longer
+	// resolve, since the scanned state has been discarded.
+	miss, err := s.Lookup("output.foo")
+	if err != nil {
+		t.Fatalf("Lookup miss: %v", err)
+	}
+	if miss != nil && miss.Value != nil {
+		t.Errorf("after DiscardScannedState, %s still resolved from scanned state: %#v",
+			"output.foo", miss.Value)
+	}
+}
+
+// TestDiscardScannedStateBeforeLookup confirms that calling
+// DiscardScannedState before any Lookup also disables the lazy scan,
+// so a key that would otherwise have been populated by it misses.
+func TestDiscardScannedStateBeforeLookup(t *testing.T) {
+	ctx := context.Background()
+	f, err := os.Open("test/terraform.tfstate")
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer f.Close()
+	s, err := tfstate.Read(ctx, f)
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+
+	s.DiscardScannedState()
+
+	obj, err := s.Lookup("output.foo")
+	if err != nil {
+		t.Fatalf("Lookup: %v", err)
+	}
+	if obj != nil && obj.Value != nil {
+		t.Errorf("after DiscardScannedState, %s still resolved: %#v",
+			"output.foo", obj.Value)
+	}
+}


### PR DESCRIPTION
## Summary

Adds `(*TFState).DiscardScannedState()`. After it is called, `Lookup` resolves keys from the override map only — both for exact matches and for the longest-prefix path — because the scanned data has been freed and the lazy scanner has been disabled.

Default behaviour is unchanged. This is purely opt-in for callers that have a reason to ignore the on-disk state.

## Why

Callers that drive every value through `SetOverrides` — e.g. a Terraform provider wrapping ecspresso that supplies tfstate-shaped values from Terraform's view of the world on every apply — should not silently inherit values from a possibly-stale tfstate file when an override is missing. After `DiscardScannedState()`, a missing key surfaces as a clean miss, which downstream consumers like ecspresso's jsonnet binding raise as `is not found in tfstate`.

The operation is one-shot — the scanned data is freed and cannot be brought back without re-Read'ing the state — which keeps the implementation tiny (just `s.once.Do(func(){})` plus nilling the maps), and matches the intended use: a provider sets up the state once at App construction and then drives the rest of the run through overrides.

## Tests

`TestDiscardScannedState` and `TestDiscardScannedStateBeforeLookup` use the existing fixture to confirm:

- Overridden keys keep resolving to the override value.
- A key that exists in the fixture stops resolving once the state is discarded.
- The lazy scanner is disabled, so calling `DiscardScannedState` before any `Lookup` also keeps the scanned data out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)